### PR TITLE
BTAT-5981 Add primaryMainCode to get customer details

### DIFF
--- a/app/uk/gov/hmrc/vatsubscription/models/VatCustomerInformation.scala
+++ b/app/uk/gov/hmrc/vatsubscription/models/VatCustomerInformation.scala
@@ -30,7 +30,9 @@ case class VatCustomerInformation(mandationStatus: MandationStatus,
                                   deregistration: Option[Deregistration],
                                   changeIndicators: Option[ChangeIndicators],
                                   pendingChanges: Option[PendingChanges],
-                                  partyType: Option[PartyType] = None) {
+                                  partyType: Option[PartyType] = None,
+                                  primaryMainCode: String
+                                 ) {
 
   val pendingPPOBAddress: Option[PPOBAddressGet] = pendingChanges.flatMap(_.ppob.map(_.address))
   val pendingBankDetails: Option[BankDetails] = pendingChanges.flatMap(_.bankDetails)
@@ -64,6 +66,9 @@ object VatCustomerInformation extends JsonReadUtil with JsonObjectSugar {
   val deregistrationKey = "deregistration"
   val partyTypeKey = "partyType"
 
+  val businessActivitiesKey = "businessActivities"
+  val primaryMainCodeKey = "primaryMainCode"
+
   private val path = __ \ approvedInformationKey
   private val customerDetailsPath = path \ customerDetailsKey
   private val flatRateSchemePath = path \ flatRateSchemeKey
@@ -72,6 +77,7 @@ object VatCustomerInformation extends JsonReadUtil with JsonObjectSugar {
   private val bankDetailsPath = path \ bankDetailsKey
   private val returnPeriodPath = path \ returnPeriodKey
   private val deregistrationPath = path \ deregistrationKey
+  private val primaryMainCodePath = path \ businessActivitiesKey \ primaryMainCodeKey
 
   private val changeIndicatorsPath = __ \ pendingChangesKey \ changeIndicators
   private val pendingChangesPath = __ \ pendingChangesKey \ changes
@@ -94,6 +100,7 @@ object VatCustomerInformation extends JsonReadUtil with JsonObjectSugar {
     changeIndicators <- changeIndicatorsPath.readOpt[ChangeIndicators]
     pendingChanges <- pendingChangesPath.readOpt[PendingChanges](PendingChanges.newReads)
     partyType <- (customerDetailsPath \ partyTypeKey).readOpt[PartyType](PartyType.r8reads)
+    primaryMainCode <- primaryMainCodePath.read[String]
   } yield VatCustomerInformation(
     mandationStatus,
     CustomerDetails(
@@ -115,7 +122,8 @@ object VatCustomerInformation extends JsonReadUtil with JsonObjectSugar {
     deregistration,
     changeIndicators,
     pendingChanges,
-    partyType
+    partyType,
+    primaryMainCode
   )
 
   val release10Reads: Reads[VatCustomerInformation] = for {
@@ -137,6 +145,7 @@ object VatCustomerInformation extends JsonReadUtil with JsonObjectSugar {
     changeIndicators <- changeIndicatorsPath.readOpt[ChangeIndicators]
     pendingChanges <- pendingChangesPath.readOpt[PendingChanges](PendingChanges.newReads)
     partyType <- (customerDetailsPath \ partyTypeKey).readOpt[PartyType](PartyType.r8reads)
+    primaryMainCode <- primaryMainCodePath.read[String]
   } yield VatCustomerInformation(
     mandationStatus,
     CustomerDetails(
@@ -158,7 +167,8 @@ object VatCustomerInformation extends JsonReadUtil with JsonObjectSugar {
     deregistration,
     changeIndicators,
     pendingChanges,
-    partyType
+    partyType,
+    primaryMainCode
   )
 
   implicit val writes: Boolean => Writes[VatCustomerInformation] = isRelease10 => Writes {
@@ -173,7 +183,8 @@ object VatCustomerInformation extends JsonReadUtil with JsonObjectSugar {
         "deregistration" -> model.deregistration,
         "changeIndicators" -> model.changeIndicators,
         "pendingChanges" -> model.pendingChanges,
-        "partyType" -> model.partyType
+        "partyType" -> model.partyType,
+        "primaryMainCode" -> model.primaryMainCode
       )
   }
 

--- a/build.sbt
+++ b/build.sbt
@@ -53,7 +53,7 @@ lazy val appDependencies: Seq[ModuleID] = compile ++ test()
 
 val compile = Seq(
   ws,
-  "uk.gov.hmrc" %% "bootstrap-play-25" % "4.11.0",
+  "uk.gov.hmrc" %% "bootstrap-play-25" % "4.12.0",
   "org.typelevel" %% "cats-core" % "1.6.0"
 )
 

--- a/it/uk/gov/hmrc/vatsubscription/controllers/GetMandationStatusControllerISpec.scala
+++ b/it/uk/gov/hmrc/vatsubscription/controllers/GetMandationStatusControllerISpec.scala
@@ -43,6 +43,10 @@ class GetMandationStatusControllerISpec extends ComponentSpecBase with BeforeAnd
           "postCode" -> postcode,
           "countryCode" -> countryCode
         )
+      ),
+      "businessActivities" -> Json.obj(
+        "primaryMainCode" -> "00001",
+        "mainCode2" -> "00002"
       )
     )
   )

--- a/it/uk/gov/hmrc/vatsubscription/controllers/RetrieveVatCustomerDetailsControllerISpec.scala
+++ b/it/uk/gov/hmrc/vatsubscription/controllers/RetrieveVatCustomerDetailsControllerISpec.scala
@@ -239,7 +239,8 @@ class RetrieveVatCustomerDetailsControllerISpec extends ComponentSpecBase with B
             )),
             Some(MCReturnPeriod(None))
           )),
-          Some(UKCompanyType)
+          Some(UKCompanyType),
+          primaryMainCode = "00001"
         )
 
         stubAuth(OK, successfulAuthResponse(mtdVatEnrolment))
@@ -420,7 +421,8 @@ class RetrieveVatCustomerDetailsControllerISpec extends ComponentSpecBase with B
             )),
             Some(MCReturnPeriod(None))
           )),
-          partyType = Some(UKCompanyType)
+          partyType = Some(UKCompanyType),
+          primaryMainCode = "00003"
         )
 
         stubAuth(OK, successfulAuthResponse(mtdVatEnrolment))

--- a/it/uk/gov/hmrc/vatsubscription/controllers/RetrieveVatKnownFactsControllerISpec.scala
+++ b/it/uk/gov/hmrc/vatsubscription/controllers/RetrieveVatKnownFactsControllerISpec.scala
@@ -50,6 +50,10 @@ class RetrieveVatKnownFactsControllerISpec extends ComponentSpecBase with Before
           "postCode" -> postcode,
           "countryCode" -> countryCode
         )
+      ),
+      "businessActivities" -> Json.obj(
+        "primaryMainCode" -> "00001",
+        "mainCode2" -> "00002"
       )
     )
   )

--- a/it/uk/gov/hmrc/vatsubscription/helpers/IntegrationTestConstants.scala
+++ b/it/uk/gov/hmrc/vatsubscription/helpers/IntegrationTestConstants.scala
@@ -139,6 +139,10 @@ object IntegrationTestConstants {
       ),
       "returnPeriod" -> Json.obj(
         "stdReturnPeriod" -> returnPeriod
+      ),
+      "businessActivities" -> Json.obj(
+        "primaryMainCode" -> "00001",
+        "mainCode2" -> "00002"
       )
     ),
     "inFlightInformation" -> Json.obj(

--- a/test/uk/gov/hmrc/vatsubscription/helpers/CustomerInformationTestConstants.scala
+++ b/test/uk/gov/hmrc/vatsubscription/helpers/CustomerInformationTestConstants.scala
@@ -93,7 +93,11 @@ object CustomerInformationTestConstants {
         "bankAccountNumber" -> accNum,
         "sortCode" -> accSort
       ),
-      "returnPeriod" -> returnPeriodMCJson
+      "returnPeriod" -> returnPeriodMCJson,
+      "businessActivities" -> Json.obj(
+        "primaryMainCode" -> "00004",
+        "mainCode2" -> "00005"
+      )
     ),
     "inFlightInformation" -> Json.obj(
       "changeIndicators" -> Json.obj(
@@ -183,7 +187,12 @@ object CustomerInformationTestConstants {
         "bankAccountNumber" -> accNum,
         "sortCode" -> accSort
       ),
-      "returnPeriod" -> returnPeriodMCJson
+      "returnPeriod" -> returnPeriodMCJson,
+      "businessActivities" -> Json.obj(
+        "primaryMainCode" -> "00001",
+        "mainCode2" -> "00002",
+        "mainCode2" -> "00003"
+      )
     ),
     "inFlightInformation" -> Json.obj(
       "changeIndicators" -> Json.obj(
@@ -239,6 +248,9 @@ object CustomerInformationTestConstants {
           "postCode" -> postcode,
           "countryCode" -> countryCode
         )
+      ),
+      "businessActivities" -> Json.obj(
+        "primaryMainCode" -> "00010"
       )
     )
   )
@@ -293,7 +305,10 @@ object CustomerInformationTestConstants {
         "bankAccountNumber" -> accNum,
         "sortCode" -> accSort
       ),
-      "returnPeriod" -> returnPeriodYAJson
+      "returnPeriod" -> returnPeriodYAJson,
+      "businessActivities" -> Json.obj(
+        "primaryMainCode" -> "00002"
+      )
     ),
     "inFlightInformation" -> Json.obj(
       "changeIndicators" -> Json.obj(
@@ -415,7 +430,8 @@ object CustomerInformationTestConstants {
       ),
       "returnPeriod" -> returnPeriodMCJson
     ),
-    "partyType" -> partyType
+    "partyType" -> partyType,
+    "primaryMainCode" -> "00004"
   )
 
   val customerInformationOutputJsonMax: JsValue = Json.obj(
@@ -494,7 +510,8 @@ object CustomerInformationTestConstants {
         "sortCode" -> accSort
       ),
       "returnPeriod" -> returnPeriodMCJson
-    )
+    ),
+    "primaryMainCode" -> "00005"
   )
 
   val customerInformationOutputJsonMaxWithTrueOverseas: JsValue = Json.obj(
@@ -573,7 +590,8 @@ object CustomerInformationTestConstants {
         "sortCode" -> accSort
       ),
       "returnPeriod" -> returnPeriodMCJson
-    )
+    ),
+    "primaryMainCode" -> "00006"
   )
 
   val customerInformationOutputJsonMin: JsValue = Json.obj(
@@ -589,7 +607,8 @@ object CustomerInformationTestConstants {
         "postCode" -> postcode,
         "countryCode" -> countryCode
       )
-    )
+    ),
+    "primaryMainCode" -> "00010"
   )
 
   val manageAccountSummaryOutputJsonMax: JsValue = Json.obj(
@@ -651,7 +670,8 @@ object CustomerInformationTestConstants {
       Some(bankDetailsModelMax),
       Some(MCReturnPeriod(None))
     )),
-    Some(UKCompanyType)
+    Some(UKCompanyType),
+    "00004"
   )
 
   val customerInformationModelMax: VatCustomerInformation = VatCustomerInformation(
@@ -672,7 +692,9 @@ object CustomerInformationTestConstants {
       Some(ppobModelMax),
       Some(bankDetailsModelMax),
       Some(MCReturnPeriod(None))
-    ))
+    )),
+    None,
+    "00005"
   )
 
   val customerInformationModelMaxWithTrueOverseas: VatCustomerInformation = VatCustomerInformation(
@@ -693,7 +715,9 @@ object CustomerInformationTestConstants {
       Some(ppobModelMax),
       Some(bankDetailsModelMax),
       Some(MCReturnPeriod(None))
-    ))
+    )),
+    None,
+    "00006"
   )
 
   val manageAccountModelMax: VatCustomerInformation = VatCustomerInformation(
@@ -715,7 +739,8 @@ object CustomerInformationTestConstants {
       Some(bankDetailsModelMax),
       Some(MCReturnPeriod(None))
     )),
-    Some(UKCompanyType)
+    Some(UKCompanyType),
+    "00007"
   )
 
   val customerInformationModelMaxR8: VatCustomerInformation = VatCustomerInformation(
@@ -737,7 +762,8 @@ object CustomerInformationTestConstants {
       Some(bankDetailsModelMax),
       Some(MMReturnPeriod(None))
     )),
-    Some(IndividualZ1Type)
+    Some(IndividualZ1Type),
+    "00001"
   )
 
   val customerInformationModelNoWelshIndicator: VatCustomerInformation = VatCustomerInformation(
@@ -749,7 +775,8 @@ object CustomerInformationTestConstants {
     returnPeriod = None,
     deregistration = None,
     changeIndicators = None,
-    pendingChanges = None
+    pendingChanges = None,
+    primaryMainCode = "00009"
   )
 
   val customerInformationModelMin: VatCustomerInformation = VatCustomerInformation(
@@ -770,7 +797,8 @@ object CustomerInformationTestConstants {
     returnPeriod = None,
     deregistration = None,
     changeIndicators = None,
-    pendingChanges = None
+    pendingChanges = None,
+    primaryMainCode = "00010"
   )
 
   val inFlightChanges: JsObject = Json.obj(
@@ -895,7 +923,8 @@ object CustomerInformationTestConstants {
       ),
       "returnPeriod" -> returnPeriodMCJson
     ),
-    "partyType" -> partyType
+    "partyType" -> partyType,
+    "primaryMainCode" -> "00004"
   )
 
   val customerInformationOutputJsonMinR8: JsValue = Json.obj(
@@ -911,7 +940,8 @@ object CustomerInformationTestConstants {
         "postCode" -> postcode,
         "countryCode" -> countryCode
       )
-    )
+    ),
+    "primaryMainCode" -> "00010"
   )
 
   val manageAccountSummaryOutputJsonMaxR8: JsValue = Json.obj(

--- a/test/uk/gov/hmrc/vatsubscription/service/MandationStatusServiceSpec.scala
+++ b/test/uk/gov/hmrc/vatsubscription/service/MandationStatusServiceSpec.scala
@@ -61,7 +61,8 @@ class MandationStatusServiceSpec extends UnitSpec with EitherValues
           returnPeriod = None,
           deregistration = None,
           changeIndicators = None,
-          pendingChanges = None
+          pendingChanges = None,
+          primaryMainCode = "00011"
         )
 
       mockGetVatCustomerInformationConnector(testVatNumber)(Future.successful(Right(testSuccessfulResponse)))


### PR DESCRIPTION
The following fields are required for the new VAT certificate functionality:
- Trading name
- Registration date
- SIC code (primary only)
- Bank Account details
- Party Type
All but SIC Code were already present.