### PR TITLE
Updated CustomerInfo calls to return JSON bodies for non-200 responses

### DIFF
--- a/app/uk/gov/hmrc/vatsubscription/connectors/GetVatCustomerInformationConnector.scala
+++ b/app/uk/gov/hmrc/vatsubscription/connectors/GetVatCustomerInformationConnector.scala
@@ -18,7 +18,7 @@ package uk.gov.hmrc.vatsubscription.connectors
 
 import javax.inject.{Inject, Singleton}
 import play.api.Logger
-import play.api.http.Status.{BAD_REQUEST, FORBIDDEN, INTERNAL_SERVER_ERROR, NOT_FOUND, OK, PRECONDITION_FAILED}
+import play.api.http.Status.{BAD_REQUEST, FORBIDDEN, NOT_FOUND, OK, PRECONDITION_FAILED}
 import play.api.libs.json.{JsSuccess, Json, Writes}
 import uk.gov.hmrc.http.logging.Authorization
 import uk.gov.hmrc.http.{HeaderCarrier, HttpReads, HttpResponse}
@@ -114,27 +114,29 @@ class GetVatCustomerInformationConnector @Inject()(val http: HttpClient,
 }
 
 sealed trait GetVatCustomerInformationFailure {
-  val status: Int = INTERNAL_SERVER_ERROR
+  val status: Int
   val body: String
 }
 
 object GetVatCustomerInformationFailure {
   implicit val writes: Writes[GetVatCustomerInformationFailure] = Writes {
-    error => Json.obj("status" -> error.status, "body" -> error.body)
+    error => Json.obj("status" -> error.status.toString, "body" -> error.body)
   }
 }
 
 case object InvalidVatNumber extends GetVatCustomerInformationFailure {
-  override val body = "Invalid vat number"
+  override val status: Int = BAD_REQUEST
+  override val body = "Bad request"
 }
 
 case object VatNumberNotFound extends GetVatCustomerInformationFailure {
-  override val body = "Vat number not found"
+  override val status: Int = NOT_FOUND
+  override val body = "Not found"
 }
 
 case object Forbidden extends GetVatCustomerInformationFailure {
   override val status: Int = FORBIDDEN
-  override val body: String = ""
+  override val body: String = "Forbidden"
 }
 
 case object Migration extends GetVatCustomerInformationFailure {

--- a/app/uk/gov/hmrc/vatsubscription/controllers/MandationStatusController.scala
+++ b/app/uk/gov/hmrc/vatsubscription/controllers/MandationStatusController.scala
@@ -43,19 +43,19 @@ class MandationStatusController @Inject()(val authConnector: AuthConnector,
           case Right(status) => Ok(Json.obj(mandationStatusKey -> status.value))
           case Left(InvalidVatNumber) =>
             Logger.debug(s"[MandationStatusController][getMandationStatus]: InvalidVatNumber returned from MandationStatusService")
-            BadRequest
+            BadRequest(Json.toJson(InvalidVatNumber))
           case Left(VatNumberNotFound) =>
             Logger.debug(s"[MandationStatusController][getMandationStatus]: VatNumberNotFound returned from MandationStatusService")
-            NotFound
+            NotFound(Json.toJson(VatNumberNotFound))
           case Left(ForbiddenResponse) =>
             Logger.debug(s"[MandationStatusController][getMandationStatus]: Forbidden returned from MandationStatusService")
-            Forbidden
+            Forbidden(Json.toJson(ForbiddenResponse))
           case Left(Migration) =>
             Logger.debug(s"[MandationStatusController][getMandationStatus]: Migration returned from MandationStatusService")
-            PreconditionFailed
+            PreconditionFailed(Json.toJson(Migration))
           case Left(UnexpectedGetVatCustomerInformationFailure(status, body)) =>
             Logger.debug(s"[MandationStatusController][getMandationStatus]: Unexpected Failure returned from MandationStatusService, status - $status")
-            Status(status)(Json.obj("status" -> status, "body" -> body))
+            Status(status)(Json.obj("status" -> status.toString, "body" -> body))
         }
       }
   }

--- a/app/uk/gov/hmrc/vatsubscription/controllers/RetrieveVatCustomerDetailsController.scala
+++ b/app/uk/gov/hmrc/vatsubscription/controllers/RetrieveVatCustomerDetailsController.scala
@@ -48,22 +48,22 @@ class RetrieveVatCustomerDetailsController @Inject()(VatAuthorised: VatAuthorise
         )))
         case Left(InvalidVatNumber) =>
           Logger.debug(s"[RetrieveVatCustomerDetailsController][retrieveVatCustomerDetails]: InvalidVatNumber returned from CustomerDetailsRetrieval Service")
-          BadRequest
+          BadRequest(Json.toJson(InvalidVatNumber))
         case Left(VatNumberNotFound) =>
           Logger.debug(s"[RetrieveVatCustomerDetailsController][retrieveVatCustomerDetails]: VatNumberNotFound returned from CustomerDetailsRetrieval Service")
-          NotFound
+          NotFound(Json.toJson(VatNumberNotFound))
         case Left(ForbiddenResult) =>
           Logger.debug(s"[RetrieveVatCustomerDetailsController][retrieveVatCustomerDetails]:" +
             s"Forbidden returned from CustomerDetailsRetrieval Service")
-          Forbidden
+          Forbidden(Json.toJson(ForbiddenResult))
         case Left(Migration) =>
           Logger.debug(s"[RetrieveVatCustomerDetailsController][retrieveVatCustomerDetails]:" +
             s"Forbidden (MIGRATION) returned from CustomerDetailsRetrieval Service")
-          PreconditionFailed
+          PreconditionFailed(Json.toJson(Migration))
         case Left(UnexpectedGetVatCustomerInformationFailure(status, body)) =>
           Logger.debug(s"[RetrieveVatCustomerDetailsController][retrieveVatCustomerDetails]:" +
             s"Unexpected Failure returned from CustomerDetailsRetrieval Service, status - $status")
-          Status(status)(Json.obj("status" -> status, "body" -> body))
+          Status(status)(Json.obj("status" -> status.toString, "body" -> body))
       }
   }
 
@@ -81,22 +81,22 @@ class RetrieveVatCustomerDetailsController @Inject()(VatAuthorised: VatAuthorise
           )))
         case Left(InvalidVatNumber) =>
           Logger.debug(s"[RetrieveVatCustomerDetailsController][retrieveVatInformation]: InvalidVatNumber returned from CustomerDetailsRetrieval Service")
-          BadRequest
+          BadRequest(Json.toJson(InvalidVatNumber))
         case Left(VatNumberNotFound) =>
           Logger.debug(s"[RetrieveVatCustomerDetailsController][retrieveVatInformation]: VatNumberNotFound returned from CustomerDetailsRetrieval Service")
-          NotFound
+          NotFound(Json.toJson(VatNumberNotFound))
         case Left(ForbiddenResult) =>
           Logger.debug(s"[RetrieveVatCustomerDetailsController][retrieveVatInformation]:" +
             s"Forbidden returned from CustomerDetailsRetrieval Service")
-          Forbidden
+          Forbidden(Json.toJson(ForbiddenResult))
         case Left(Migration) =>
           Logger.debug(s"[RetrieveVatCustomerDetailsController][retrieveVatInformation]:" +
             s"Forbidden (MIGRATION) returned from CustomerDetailsRetrieval Service")
-          PreconditionFailed
+          PreconditionFailed(Json.toJson(Migration))
         case Left(UnexpectedGetVatCustomerInformationFailure(status, body)) =>
           Logger.debug(s"[RetrieveVatCustomerDetailsController][retrieveVatInformation]:" +
             s"Unexpected Failure returned from CustomerDetailsRetrieval Service, status - $status")
-          Status(status)(Json.obj("status" -> status, "body" -> body))
+          Status(status)(Json.obj("status" -> status.toString, "body" -> body))
       }
   }
 
@@ -111,22 +111,22 @@ class RetrieveVatCustomerDetailsController @Inject()(VatAuthorised: VatAuthorise
         )))
         case Left(InvalidVatNumber) =>
           Logger.debug(s"[RetrieveVatCustomerDetailsController][manageAccountSummary]: InvalidVatNumber returned from CustomerDetailsRetrieval Service")
-          BadRequest
+          BadRequest(Json.toJson(InvalidVatNumber))
         case Left(VatNumberNotFound) =>
           Logger.debug(s"[RetrieveVatCustomerDetailsController][manageAccountSummary]: VatNumberNotFound returned from CustomerDetailsRetrieval Service")
-          NotFound
+          NotFound(Json.toJson(VatNumberNotFound))
         case Left(ForbiddenResult) =>
           Logger.debug(s"[RetrieveVatCustomerDetailsController][manageAccountSummary]:" +
             s"Forbidden returned from CustomerDetailsRetrieval Service")
-          Forbidden
+          Forbidden(Json.toJson(ForbiddenResult))
         case Left(Migration) =>
           Logger.debug(s"[RetrieveVatCustomerDetailsController][manageAccountSummary]:" +
             s"Forbidden (MIGRATION) returned from CustomerDetailsRetrieval Service")
-          PreconditionFailed
+          PreconditionFailed(Json.toJson(Migration))
         case Left(UnexpectedGetVatCustomerInformationFailure(status, body)) =>
           Logger.debug(s"[RetrieveVatCustomerDetailsController][manageAccountSummary]:" +
             s"Unexpected Failure returned from CustomerDetailsRetrieval Service, status - $status")
-          Status(status)(Json.obj("status" -> status, "body" -> body))
+          Status(status)(Json.obj("status" -> status.toString, "body" -> body))
       }
   }
 }

--- a/test/uk/gov/hmrc/vatsubscription/controllers/MandationStatusControllerSpec.scala
+++ b/test/uk/gov/hmrc/vatsubscription/controllers/MandationStatusControllerSpec.scala
@@ -57,6 +57,7 @@ class MandationStatusControllerSpec extends TestUtil
 
       val res = TestMandationStatusController.getMandationStatus(testVatNumber)(FakeRequest())
       status(res) shouldBe BAD_REQUEST
+      jsonBodyOf(await(res)) shouldBe Json.toJson(InvalidVatNumber)
     }
 
     "return the NOT_FOUND when VatNumberNotFound" in {
@@ -66,6 +67,7 @@ class MandationStatusControllerSpec extends TestUtil
 
       val res = TestMandationStatusController.getMandationStatus(testVatNumber)(FakeRequest())
       status(res) shouldBe NOT_FOUND
+      jsonBodyOf(await(res)) shouldBe Json.toJson(VatNumberNotFound)
     }
 
     "return the FORBIDDEN when Forbidden with no json body" in {
@@ -75,6 +77,7 @@ class MandationStatusControllerSpec extends TestUtil
 
       val res = TestMandationStatusController.getMandationStatus(testVatNumber)(FakeRequest())
       status(res) shouldBe FORBIDDEN
+      jsonBodyOf(await(res)) shouldBe Json.toJson(Forbidden)
     }
 
     "return the PRECONDITION_FAILED when Forbidden with MIGRATION code in json body" in {
@@ -84,6 +87,7 @@ class MandationStatusControllerSpec extends TestUtil
 
       val res = TestMandationStatusController.getMandationStatus(testVatNumber)(FakeRequest())
       status(res) shouldBe PRECONDITION_FAILED
+      jsonBodyOf(await(res)) shouldBe Json.toJson(Migration)
     }
 
     "return the INTERNAL_SERVER_ERROR and the error when failed unexpectedly" in {
@@ -94,7 +98,7 @@ class MandationStatusControllerSpec extends TestUtil
       val res = TestMandationStatusController.getMandationStatus(testVatNumber)(FakeRequest())
       status(res) shouldBe INTERNAL_SERVER_ERROR
 
-      jsonBodyOf(await(res)) shouldBe Json.obj("status" -> INTERNAL_SERVER_ERROR, "body" -> "failure")
+      jsonBodyOf(await(res)) shouldBe Json.obj("status" -> INTERNAL_SERVER_ERROR.toString, "body" -> "failure")
     }
   }
 

--- a/test/uk/gov/hmrc/vatsubscription/controllers/RetrieveVatCustomerDetailsControllerSpec.scala
+++ b/test/uk/gov/hmrc/vatsubscription/controllers/RetrieveVatCustomerDetailsControllerSpec.scala
@@ -106,6 +106,7 @@ class RetrieveVatCustomerDetailsControllerSpec extends TestUtil with MockVatAuth
           val res: Result = await(TestRetrieveVatCustomerDetailsController.retrieveVatCustomerDetails(testVatNumber)(FakeRequest()))
 
           status(res) shouldBe BAD_REQUEST
+          jsonBodyOf(res) shouldBe Json.toJson(InvalidVatNumber)
         }
       }
 
@@ -117,6 +118,7 @@ class RetrieveVatCustomerDetailsControllerSpec extends TestUtil with MockVatAuth
           val res: Result = await(TestRetrieveVatCustomerDetailsController.retrieveVatCustomerDetails(testVatNumber)(FakeRequest()))
 
           status(res) shouldBe NOT_FOUND
+          jsonBodyOf(res) shouldBe Json.toJson(VatNumberNotFound)
         }
       }
 
@@ -128,6 +130,7 @@ class RetrieveVatCustomerDetailsControllerSpec extends TestUtil with MockVatAuth
           val res: Result = await(TestRetrieveVatCustomerDetailsController.retrieveVatCustomerDetails(testVatNumber)(FakeRequest()))
 
           status(res) shouldBe FORBIDDEN
+          jsonBodyOf(res) shouldBe Json.toJson(Forbidden)
         }
       }
 
@@ -137,7 +140,9 @@ class RetrieveVatCustomerDetailsControllerSpec extends TestUtil with MockVatAuth
           mockRetrieveVatCustomerDetails(testVatNumber)(Future.successful(Left(Migration)))
 
           val res: Result = await(TestRetrieveVatCustomerDetailsController.retrieveVatCustomerDetails(testVatNumber)(FakeRequest()))
+
           status(res) shouldBe PRECONDITION_FAILED
+          jsonBodyOf(res) shouldBe Json.toJson(Migration)
         }
 
 
@@ -154,7 +159,7 @@ class RetrieveVatCustomerDetailsControllerSpec extends TestUtil with MockVatAuth
             val res: Result = await(TestRetrieveVatCustomerDetailsController.retrieveVatCustomerDetails(testVatNumber)(FakeRequest()))
 
             status(res) shouldBe INTERNAL_SERVER_ERROR
-            jsonBodyOf(await(res)) shouldBe Json.obj("status" -> INTERNAL_SERVER_ERROR, "body" -> responseBody)
+            jsonBodyOf(await(res)) shouldBe Json.obj("status" -> INTERNAL_SERVER_ERROR.toString, "body" -> responseBody)
           }
         }
       }
@@ -234,6 +239,7 @@ class RetrieveVatCustomerDetailsControllerSpec extends TestUtil with MockVatAuth
 
             val res: Result = await(TestRetrieveVatCustomerDetailsController.retrieveVatInformation(testVatNumber)(FakeRequest()))
             status(res) shouldBe BAD_REQUEST
+            jsonBodyOf(res) shouldBe Json.toJson(InvalidVatNumber)
           }
         }
       }
@@ -245,6 +251,7 @@ class RetrieveVatCustomerDetailsControllerSpec extends TestUtil with MockVatAuth
 
           val res: Result = await(TestRetrieveVatCustomerDetailsController.retrieveVatInformation(testVatNumber)(FakeRequest()))
           status(res) shouldBe NOT_FOUND
+          jsonBodyOf(res) shouldBe Json.toJson(VatNumberNotFound)
         }
       }
 
@@ -255,6 +262,7 @@ class RetrieveVatCustomerDetailsControllerSpec extends TestUtil with MockVatAuth
 
           val res: Result = await(TestRetrieveVatCustomerDetailsController.retrieveVatInformation(testVatNumber)(FakeRequest()))
           status(res) shouldBe FORBIDDEN
+          jsonBodyOf(res) shouldBe Json.toJson(Forbidden)
         }
       }
 
@@ -265,6 +273,7 @@ class RetrieveVatCustomerDetailsControllerSpec extends TestUtil with MockVatAuth
 
           val res: Result = await(TestRetrieveVatCustomerDetailsController.retrieveVatInformation(testVatNumber)(FakeRequest()))
           status(res) shouldBe PRECONDITION_FAILED
+          jsonBodyOf(res) shouldBe Json.toJson(Migration)
         }
       }
 
@@ -279,7 +288,7 @@ class RetrieveVatCustomerDetailsControllerSpec extends TestUtil with MockVatAuth
           val res: Result = await(TestRetrieveVatCustomerDetailsController.retrieveVatInformation(testVatNumber)(FakeRequest()))
 
           status(res) shouldBe INTERNAL_SERVER_ERROR
-          jsonBodyOf(await(res)) shouldBe Json.obj("status" -> INTERNAL_SERVER_ERROR, "body" -> responseBody)
+          jsonBodyOf(await(res)) shouldBe Json.obj("status" -> INTERNAL_SERVER_ERROR.toString, "body" -> responseBody)
         }
       }
     }


### PR DESCRIPTION
This change was made as a reaction to exceptions being thrown by vat-summary-frontend due to it trying to parse JSON when it received an error with status code 400 (e.g. the recurring MALFORMED_PAYLOAD errors).