### PR TITLE
BTAT-9025 Updated JSON reads/writes to handle inflight organisation name

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,8 @@ Where:
         "firstName": "Frank",
         "middleName": "Andrew",
         "lastName": "Grimes",
+        "organisationName": "Example Business Name",
+        "tradingName": "Example Trading Name",
         "vatRegistrationDate": "2018-01-01",
         "customerMigratedToETMPDate": "2018-01-01",
         "hybridToFullMigrationDate": "2018-01-01",
@@ -184,17 +186,45 @@ Where:
         }
     },
     "changeIndicators": {
-        "organisationDetails": false,
-        "PPOBDetails": false,
-        "bankDetails": false,
+        "organisationDetails": true,
+        "PPOBDetails": true,
+        "bankDetails": true,
         "returnPeriod": true,
         "deregister": false,
         "annualAccounting": false
     },
     "pendingChanges": {
+        "PPOBDetails": {
+            "address": {
+                "line1": "New Add Line 1",
+                "line2": "New Add Line 2",
+                "line3": "New Add Line 3",
+                "line4": "New Add Line 4",
+                "line5": "New Add Line 5",
+                "postCode": "NE33WER",
+                "countryCode": "GB"
+            },
+            "contactDetails": {
+                "primaryPhoneNumber": "112345678902",
+                "mobileNumber": "112345678903",
+                "faxNumber": "112345678904",
+                "emailAddress": "testuser234@test.com",
+                "emailVerified": true
+            },
+            "websiteAddress": "www.site.biz"
+        },
+        "bankDetails": {
+            "accountHolderName": "Monty Mole",
+            "bankAccountNumber": "****9999",
+            "sortCode": "99****"
+        },
         "returnPeriod": {
-            "stdReturnPeriod": "MB"
-        }
+            "stdReturnPeriod": "MM"
+        },
+        "mandationStatus": "MTDfB Exempt",
+        "commsPreference": "PAPER",
+        "tradingName": "New Trading Name",
+        "organisationName": "New Business Name"
     },
     "partyType": "50",
     "primaryMainCode": "10410",
@@ -210,7 +240,7 @@ Where:
 * **bankDetails** is optional and its elements are also all optional.
 * **returnPeriod** is optional and its elements are also all optional.
 * **changeIndicators** is optional and consists of mandatory boolean values to denote which sections of data have pending changes.
-* **pendingChanges** is optional and consists of optional elements "ppob", "bankDetails", "returnPeriod", "mandationStatus", "commsPreference" and "tradingName".
+* **pendingChanges** is optional and consists of optional elements "ppob", "bankDetails", "returnPeriod", "mandationStatus", "commsPreference", "tradingName" and "organisationName".
 * **partyType** is optional.
 * **primaryMainCode** is mandatory.
 * **missingTrader** is mandatory.

--- a/app/models/PendingChanges.scala
+++ b/app/models/PendingChanges.scala
@@ -28,7 +28,8 @@ case class PendingChanges(ppob: Option[PPOBGet],
                           returnPeriod: Option[ReturnPeriod],
                           mandationStatus: Option[MandationStatus],
                           commsPreference: Option[CommsPreference],
-                          tradingName: Option[String])
+                          tradingName: Option[String],
+                          organisationName: Option[String])
 
 object PendingChanges {
 
@@ -38,6 +39,7 @@ object PendingChanges {
   private val mandationStatusDesPath = __ \ "mandationStatus" \ "mandationStatus"
   private val commsPreferenceDesPath = __ \ "commsPreference" \ "commsPreference"
   private val tradingNamePath = __ \ "organisationDetails" \ "tradingName"
+  private val organisationNamePath = __ \ "organisationDetails" \ "organisationName"
 
   val reads: AppConfig => Reads[PendingChanges] = conf => for {
     ppob <- ppobPath.readNullable[PPOBGet]
@@ -48,18 +50,21 @@ object PendingChanges {
     ).orElse(Reads.pure(None))
     commsPref <- commsPreferenceDesPath.readNullable[CommsPreference].orElse(Reads.pure(None))
     tradingName <- tradingNamePath.readNullable[String].orElse(Reads.pure(None))
+    organisationName <- organisationNamePath.readNullable[String].orElse(Reads.pure(None))
   } yield PendingChanges(
     ppob,
     bankDetails,
     filterReturnPeriod(returnPeriod, conf),
     mandationStatus,
     commsPref,
-    tradingName
+    tradingName,
+    organisationName
   )
 
   private val mandationStatusWritesPath = __ \ "mandationStatus"
   private val commsPreferenceWritesPath = __ \ "commsPreference"
   private val tradingNameWritesPath = __ \ "tradingName"
+  private val organisationNameWritesPath = __ \ "organisationName"
 
   implicit val writes: Writes[PendingChanges] = (
     ppobPath.writeNullable[PPOBGet] and
@@ -67,6 +72,7 @@ object PendingChanges {
     returnPeriodPath.writeNullable[ReturnPeriod] and
     mandationStatusWritesPath.writeNullable[MandationStatus](MandationStatus.writer) and
     commsPreferenceWritesPath.writeNullable[CommsPreference](CommsPreference.writes) and
-    tradingNameWritesPath.writeNullable[String]
+    tradingNameWritesPath.writeNullable[String] and
+    organisationNameWritesPath.writeNullable[String]
   )(unlift(PendingChanges.unapply))
 }

--- a/it/controllers/RetrieveVatCustomerDetailsControllerISpec.scala
+++ b/it/controllers/RetrieveVatCustomerDetailsControllerISpec.scala
@@ -258,7 +258,8 @@ class RetrieveVatCustomerDetailsControllerISpec extends ComponentSpecBase with B
             Some(MCReturnPeriod(None, None, None)),
             Some(MTDfB),
             Some(DigitalPreference),
-            Some(tradingName)
+            Some(tradingName),
+            Some(orgName)
           )),
           Some(UKCompanyType),
           primaryMainCode = "00001",

--- a/it/helpers/IntegrationTestConstants.scala
+++ b/it/helpers/IntegrationTestConstants.scala
@@ -194,7 +194,8 @@ object IntegrationTestConstants {
           "commsPreference" -> DigitalPreference.desValue
         ),
         "organisationDetails" -> Json.obj(
-          "tradingName" -> tradingName
+          "tradingName" -> tradingName,
+          "organisationName" -> orgName
         )
       )
     )

--- a/test/helpers/CustomerInformationTestConstants.scala
+++ b/test/helpers/CustomerInformationTestConstants.scala
@@ -33,6 +33,38 @@ object CustomerInformationTestConstants {
   val effectiveDate = "1967-08-13"
   val startDate = "1967-08-13"
 
+  val pendingChangesOutputMax: JsObject = Json.obj(
+    "PPOBDetails" -> Json.obj(
+      "address" -> Json.obj(
+        "line1" -> addLine1,
+        "line2" -> addLine2,
+        "line3" -> addLine3,
+        "line4" -> addLine4,
+        "line5" -> addLine5,
+        "postCode" -> postcode,
+        "countryCode" -> countryCode
+      ),
+      "contactDetails" -> Json.obj(
+        "primaryPhoneNumber" -> phoneNumber,
+        "mobileNumber" -> mobileNumber,
+        "faxNumber" -> faxNumber,
+        "emailAddress" -> email,
+        "emailVerified" -> emailVerified
+      ),
+      "websiteAddress" -> website
+    ),
+    "bankDetails" -> Json.obj(
+      "accountHolderName" -> accName,
+      "bankAccountNumber" -> accNum,
+      "sortCode" -> accSort
+    ),
+    "returnPeriod" -> returnPeriodMCJson,
+    "mandationStatus" -> "MTDfB",
+    "commsPreference" -> "DIGITAL",
+    "tradingName" -> tradingName,
+    "organisationName" -> orgName
+  )
+
   val customerInformationDESJsonMaxWithFRS: JsValue = Json.obj(
     "approvedInformation" -> Json.obj(
       "customerDetails" -> Json.obj(
@@ -145,7 +177,8 @@ object CustomerInformationTestConstants {
           "commsPreference" -> "ZEL"
         ),
         "organisationDetails" -> Json.obj(
-          "tradingName" -> tradingName
+          "tradingName" -> tradingName,
+          "organisationName" -> orgName
         )
       )
     )
@@ -295,36 +328,7 @@ object CustomerInformationTestConstants {
       "deregister" -> true,
       "annualAccounting" -> true
     ),
-    "pendingChanges" -> Json.obj(
-      "PPOBDetails" -> Json.obj(
-        "address" -> Json.obj(
-          "line1" -> addLine1,
-          "line2" -> addLine2,
-          "line3" -> addLine3,
-          "line4" -> addLine4,
-          "line5" -> addLine5,
-          "postCode" -> postcode,
-          "countryCode" -> countryCode
-        ),
-        "contactDetails" -> Json.obj(
-          "primaryPhoneNumber" -> phoneNumber,
-          "mobileNumber" -> mobileNumber,
-          "faxNumber" -> faxNumber,
-          "emailAddress" -> email,
-          "emailVerified" -> emailVerified
-        ),
-        "websiteAddress" -> website
-      ),
-      "bankDetails" -> Json.obj(
-        "accountHolderName" -> accName,
-        "bankAccountNumber" -> accNum,
-        "sortCode" -> accSort
-      ),
-      "returnPeriod" -> returnPeriodMCJson,
-      "mandationStatus" -> MTDfB.value,
-      "commsPreference" -> DigitalPreference.mdtpValue,
-      "tradingName" -> tradingName
-    ),
+    "pendingChanges" -> pendingChangesOutputMax,
     "partyType" -> partyType,
     "primaryMainCode" -> "00004",
     "missingTrader" -> true,
@@ -372,36 +376,7 @@ object CustomerInformationTestConstants {
       "deregister" -> true,
       "annualAccounting" -> true
     ),
-    "pendingChanges" -> Json.obj(
-      "PPOBDetails" -> Json.obj(
-        "address" -> Json.obj(
-          "line1" -> addLine1,
-          "line2" -> addLine2,
-          "line3" -> addLine3,
-          "line4" -> addLine4,
-          "line5" -> addLine5,
-          "postCode" -> postcode,
-          "countryCode" -> countryCode
-        ),
-        "contactDetails" -> Json.obj(
-          "primaryPhoneNumber" -> phoneNumber,
-          "mobileNumber" -> mobileNumber,
-          "faxNumber" -> faxNumber,
-          "emailAddress" -> email,
-          "emailVerified" -> emailVerified
-        ),
-        "websiteAddress" -> website
-      ),
-      "bankDetails" -> Json.obj(
-        "accountHolderName" -> accName,
-        "bankAccountNumber" -> accNum,
-        "sortCode" -> accSort
-      ),
-      "returnPeriod" -> returnPeriodMCJson,
-      "mandationStatus" -> MTDfB.value,
-      "commsPreference" -> DigitalPreference.mdtpValue,
-      "tradingName" -> tradingName
-    ),
+    "pendingChanges" -> pendingChangesOutputMax,
     "primaryMainCode" -> "00005",
     "missingTrader" -> true,
     "commsPreference" -> DigitalPreference.mdtpValue
@@ -448,36 +423,7 @@ object CustomerInformationTestConstants {
       "deregister" -> true,
       "annualAccounting" -> true
     ),
-    "pendingChanges" -> Json.obj(
-      "PPOBDetails" -> Json.obj(
-        "address" -> Json.obj(
-          "line1" -> addLine1,
-          "line2" -> addLine2,
-          "line3" -> addLine3,
-          "line4" -> addLine4,
-          "line5" -> addLine5,
-          "postCode" -> postcode,
-          "countryCode" -> countryCode
-        ),
-        "contactDetails" -> Json.obj(
-          "primaryPhoneNumber" -> phoneNumber,
-          "mobileNumber" -> mobileNumber,
-          "faxNumber" -> faxNumber,
-          "emailAddress" -> email,
-          "emailVerified" -> emailVerified
-        ),
-        "websiteAddress" -> website
-      ),
-      "bankDetails" -> Json.obj(
-        "accountHolderName" -> accName,
-        "bankAccountNumber" -> accNum,
-        "sortCode" -> accSort
-      ),
-      "returnPeriod" -> returnPeriodMCJson,
-      "mandationStatus" -> MTDfB.value,
-      "commsPreference" -> DigitalPreference.mdtpValue,
-      "tradingName" -> tradingName
-    ),
+    "pendingChanges" -> pendingChangesOutputMax,
     "primaryMainCode" -> "00006",
     "missingTrader" -> true,
     "commsPreference" -> DigitalPreference.mdtpValue
@@ -527,7 +473,8 @@ object CustomerInformationTestConstants {
       Some(MCReturnPeriod(None, None, None)),
       Some(MTDfB),
       Some(DigitalPreference),
-      Some(tradingName)
+      Some(tradingName),
+      Some(orgName)
     )),
     Some(UKCompanyType),
     "00004",
@@ -585,7 +532,8 @@ object CustomerInformationTestConstants {
       Some(MCReturnPeriod(None, None, None)),
       Some(MTDfB),
       Some(DigitalPreference),
-      Some(tradingName)
+      Some(tradingName),
+      Some(orgName)
     )),
     None,
     "00005",
@@ -615,7 +563,8 @@ object CustomerInformationTestConstants {
       Some(MCReturnPeriod(None, None, None)),
       Some(MTDfB),
       Some(DigitalPreference),
-      Some(tradingName)
+      Some(tradingName),
+      Some(orgName)
     )),
     None,
     "00006",
@@ -677,7 +626,7 @@ object CustomerInformationTestConstants {
       "bankAccountNumber" -> accNum,
       "sortCode" -> accSort
     ),
-    "returnPeriod" -> inflightReturnPeriodMAJson,
+    "returnPeriod" -> inflightReturnPeriodMCJson,
     "mandationStatus" -> Json.obj(
       "mandationStatus" -> mandationStatusCode
     ),
@@ -685,7 +634,8 @@ object CustomerInformationTestConstants {
       "commsPreference" -> "ZEL"
     ),
     "organisationDetails" -> Json.obj(
-      "tradingName" -> tradingName
+      "tradingName" -> tradingName,
+      "organisationName" -> orgName
     )
   )
 

--- a/test/models/PendingChangesSpec.scala
+++ b/test/models/PendingChangesSpec.scala
@@ -19,7 +19,7 @@ package models
 import assets.TestUtil
 import play.api.libs.json.{JsError, Json}
 import helpers.BankDetailsTestConstants.bankDetailsModelMax
-import helpers.BaseTestConstants.tradingName
+import helpers.BaseTestConstants.{orgName, tradingName}
 import helpers.CustomerInformationTestConstants._
 import helpers.PPOBTestConstants.ppobModelMax
 
@@ -34,14 +34,19 @@ class PendingChangesSpec extends TestUtil {
         val model = PendingChanges(
           Some(ppobModelMax),
           Some(bankDetailsModelMax),
-          Some(MAReturnPeriod(None, None, None)),
+          Some(MCReturnPeriod(None, None, None)),
           Some(MTDfB),
           Some(DigitalPreference),
-          Some(tradingName)
+          Some(tradingName),
+          Some(orgName)
         )
 
-        "parse the json correctly" in {
-          PendingChanges.reads(mockAppConfig).reads(inFlightChanges).get shouldEqual model
+        "read from JSON" in {
+          PendingChanges.reads(mockAppConfig).reads(inFlightChanges).get shouldBe model
+        }
+
+        "write to JSON" in {
+          PendingChanges.writes.writes(model) shouldBe pendingChangesOutputMax
         }
       }
 
@@ -50,23 +55,30 @@ class PendingChangesSpec extends TestUtil {
         val model = PendingChanges(
           Some(ppobModelMax),
           Some(bankDetailsModelMax),
-          Some(MAReturnPeriod(None, None, None)),
+          Some(MCReturnPeriod(None, None, None)),
           Some(MTDfBVoluntary),
           Some(DigitalPreference),
-          Some(tradingName)
+          Some(tradingName),
+          Some(orgName)
         )
 
-        "parse the json correctly" in {
+        "read from JSON" in {
           mockAppConfig.features.newStatusIndicators(false)
-          PendingChanges.reads(mockAppConfig).reads(inFlightChanges).get shouldEqual model
+          PendingChanges.reads(mockAppConfig).reads(inFlightChanges).get shouldBe model
         }
       }
     }
 
     "no optional fields are populated" should {
 
-      "parse the json correctly" in {
-        PendingChanges.reads(mockAppConfig).reads(Json.obj()).get shouldEqual PendingChanges(None, None, None, None, None, None)
+      val model = PendingChanges(None, None, None, None, None, None, None)
+
+      "read from JSON" in {
+        PendingChanges.reads(mockAppConfig).reads(Json.obj()).get shouldBe model
+      }
+
+      "write to JSON" in {
+        PendingChanges.writes.writes(model) shouldBe Json.obj()
       }
     }
 

--- a/test/models/VatCustomerInformationSpec.scala
+++ b/test/models/VatCustomerInformationSpec.scala
@@ -19,7 +19,7 @@ package models
 import assets.TestUtil
 import play.api.libs.json.Json
 import helpers.BankDetailsTestConstants.bankDetailsModelMax
-import helpers.BaseTestConstants.tradingName
+import helpers.BaseTestConstants.{orgName, tradingName}
 import helpers.CustomerInformationTestConstants._
 import helpers.PPOBTestConstants.{email, mobileNumber, phoneNumber, ppobModelMax}
 
@@ -130,7 +130,8 @@ class VatCustomerInformationSpec extends TestUtil {
           Some(MCReturnPeriod(None, None, None)),
           Some(MTDfBVoluntary),
           Some(DigitalPreference),
-          Some(tradingName)
+          Some(tradingName),
+          Some(orgName)
         ))
       )
 


### PR DESCRIPTION
I considered putting the pending trading & organisation name in an "organisationDetails" block with its own model but it would have knock on effects to other services and at this late stage it's not wise.

I've also updated the readme JSON to give a better example of the pending changes that can be returned.